### PR TITLE
Update requirements.txt

### DIFF
--- a/data_processing_lib/requirements.txt
+++ b/data_processing_lib/requirements.txt
@@ -1,7 +1,6 @@
   numpy < 1.29.0
   pyarrow==16.1.0
   boto3==1.34.69
-  argparse
   mmh3
   psutil
   polars


### PR DESCRIPTION
The `argparse` module was included in Python 3.2 and has not been updated since 2015. 

## Why are these changes needed?
In Python 2.9, some changes were made in the standard library module, but not in the external abandoned module. As a result, some programs that depend on modern features fail.


